### PR TITLE
feat: added impacket path locator, and parsing from raw input

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,34 @@ Impacket v0.12.0 - Copyright Fortra, LLC and its affiliated companies
 [+] done
 [+] cacche saved: ticket.cacche
 ```
+
+## from input (1)
+
+```
+echo "doIFrjCCBaqg...FVQUEVULlZM" | ./RTC.py 
+[+] using ticketConverter.py
+[+] text provided: doIFrjCCBaqg...FVQUEVULlZM
+[+] text file saved: ticket.kirbii
+Impacket v0.13.0.dev0+20241220.182433.9c8e4083 - Copyright Fortra, LLC and its affiliated companies 
+
+[*] converting kirbi to ccache...
+[+] done
+[+] cacche saved: ticket.cacche
+
+```
+
+## from input (2)
+
+```
+└─$ ./RTC.py
+[+] using ticketConverter.py
+doIFrjCCBaqg...FVQUEVULlZM
+
+[+] text provided: doIFrjCCBaqg...FVQUEVULlZM
+[+] text file saved: ticket.kirbii
+Impacket v0.13.0.dev0+20241220.182433.9c8e4083 - Copyright Fortra, LLC and its affiliated companies 
+
+[*] converting kirbi to ccache...
+[+] done
+[+] cacche saved: ticket.cacche
+```

--- a/RTC.py
+++ b/RTC.py
@@ -4,6 +4,7 @@ import subprocess
 import argparse
 import base64
 import re
+import shutil
 
 # Initialize parser
 parser = argparse.ArgumentParser()
@@ -15,6 +16,21 @@ parser.add_argument("-r", "--read", help="The base64 text itself containing the 
 # Read arguments from command line
 args = parser.parse_args()
 
+tcs = [ "impacket-ticketConverter", "ticketConverter.py", "ticketConverter" ]
+tc = ""
+for t in tcs:
+    if shutil.which(t):
+        print(f"[+] using {t}")
+        tc = t
+        break
+
+if ( not tc ): 
+    print( "[-] ticketConverter not found" )
+    exit(1)
+
+if ( not args.file ) and ( not args.read ):
+    args.read = input()
+
 # Handle file argument
 if args.file:
     print(f"[+] text file provided: {args.file}")
@@ -25,7 +41,7 @@ if args.file:
     with open(f'{cut_name}.kirbii', "wb") as f:
         f.write(decoded_file)
     print(f"[+] kirbii file saved: {cut_name}.kirbii")
-    os.system(f'impacket-ticketConverter {cut_name}.kirbii "{cut_name}.ccache"')
+    os.system(f'{tc} {cut_name}.kirbii "{cut_name}.ccache"')
     print(f"[+] ccache file saved: {cut_name}.cacche")
 
 
@@ -35,5 +51,5 @@ if args.read:
     with open(f'ticket.kirbii', "wb") as f:
         f.write(decoded_read)
     print(f"[+] text file saved: ticket.kirbii")
-    os.system(f'impacket-ticketConverter ticket.kirbii "ticket.ccache"')
+    os.system(f'{tc} ticket.kirbii "ticket.ccache"')
     print(f"[+] cacche saved: ticket.cacche")


### PR DESCRIPTION
* added a small feature to locate `ticketConverter.py`, incase people decide to install from src - or if it's not added to `PATH` at least it's easy to modify the script to add that as a findable location

* added functionality to pass raw input into the script

```
echo "doIFrjCCBaqg...FVQUEVULlZM" | ./RTC.py 
[+] using ticketConverter.py
[+] text provided: doIFrjCCBaqg...FVQUEVULlZM
[+] text file saved: ticket.kirbii
Impacket v0.13.0.dev0+20241220.182433.9c8e4083 - Copyright Fortra, LLC and its affiliated companies 

[*] converting kirbi to ccache...
[+] done
[+] cacche saved: ticket.cacche
```

```
└─$ ./RTC.py
[+] using ticketConverter.py
doIFrjCCBaqg...FVQUEVULlZM

[+] text provided: doIFrjCCBaqg...FVQUEVULlZM
[+] text file saved: ticket.kirbii
Impacket v0.13.0.dev0+20241220.182433.9c8e4083 - Copyright Fortra, LLC and its affiliated companies 

[*] converting kirbi to ccache...
[+] done
[+] cacche saved: ticket.cacche
```